### PR TITLE
Improve the `Miou_unix.Cond` API

### DIFF
--- a/lib/miou_unix.ml
+++ b/lib/miou_unix.ml
@@ -161,16 +161,11 @@ module Cond = struct
     in
     go ()
 
-  let wait ~predicate t =
-    let wait = with_lock ~lock:t.mutex_predicate predicate in
-    if wait then begin
-      with_lock ~lock:t.mutex_counter (fun () -> t.counter <- t.counter + 1);
-      blocking_read t.ic;
-      consume_signal t.ic;
-      with_lock ~lock:t.mutex_counter (fun () -> t.counter <- t.counter - 1);
-      with_lock ~lock:t.mutex_predicate predicate
-    end
-    else false
+  let wait t =
+    with_lock ~lock:t.mutex_counter (fun () -> t.counter <- t.counter + 1);
+    blocking_read t.ic;
+    consume_signal t.ic;
+    with_lock ~lock:t.mutex_counter (fun () -> t.counter <- t.counter - 1)
 
   let until ~predicate ~fn t =
     Mutex.lock t.mutex_predicate;


### PR DESCRIPTION
/cc @darrenldl, a fix for #5 

Currently, Conditions in Miou are a bit different than usual. Internally, we use a `pipe()` to allow the inter-processs communication. I made a first short about the API where I did not really figure out about details. This PR specify the API and the documentation according to implementation details.

For instance, we should not have spurious wakeups when we actually try to read into our `pipe()`. However, I kept the same semantic than POSIX condition: if we signal a condition but nobody waits, we do nothing. `t02` shows an usual usage of `Miou_unix.Cond`, we must have a mutex to check _a predicate_. It's like what the API provides: `Miou_unix.Cond.until`.