### PR TITLE
Match the type of Miou_unix.write with Unix.write and Lwt_unix.write

### DIFF
--- a/examples/happy/happy.ml
+++ b/examples/happy/happy.ml
@@ -346,7 +346,7 @@ let send_recv (timeout, fd) ({ Cstruct.len; _ } as tx) =
     | Unix.SOCK_STREAM -> (
         let fn () =
           Log.debug (fun m -> m "send a packet to resolver");
-          Miou_unix.write fd ~off:0 ~len (Cstruct.to_string tx);
+          Miou_unix.write fd ~off:0 ~len (Cstruct.to_bytes tx);
           let id = Cstruct.BE.get_uint16 tx 2 in
           Log.debug (fun m -> m "recv a packet from resolver");
           let packet = read_loop ~id `Tcp fd in

--- a/lib/miou_unix.ml
+++ b/lib/miou_unix.ml
@@ -208,24 +208,24 @@ let rec read ({ fd; non_blocking; owner; _ } as file_descr) buf ~off ~len =
     in
     blocking_read fd; go ()
 
-let rec write ({ fd; non_blocking; owner; _ } as file_descr) str ~off ~len =
+let rec write ({ fd; non_blocking; owner; _ } as file_descr) bytes ~off ~len =
   Miou.Ownership.check owner;
   if non_blocking then
-    match Unix.write fd (Bytes.unsafe_of_string str) off len with
+    match Unix.write fd bytes off len with
     | exception Unix.(Unix_error (EINTR, _, _)) ->
-        write file_descr str ~off ~len
+        write file_descr bytes ~off ~len
     | exception Unix.(Unix_error ((EAGAIN | EWOULDBLOCK), _, _)) ->
         blocking_write fd;
-        write file_descr str ~off ~len
+        write file_descr bytes ~off ~len
     | len' when len' < len ->
-        write file_descr str ~off:(off + len') ~len:(len - len')
+        write file_descr bytes ~off:(off + len') ~len:(len - len')
     | _ -> ()
   else
     let rec go () =
-      match Unix.write fd (Bytes.unsafe_of_string str) off len with
+      match Unix.write fd bytes off len with
       | exception Unix.(Unix_error (EINTR, _, _)) -> go ()
       | len' when len' < len ->
-          write file_descr str ~off:(off + len') ~len:(len - len')
+          write file_descr bytes ~off:(off + len') ~len:(len - len')
       | _ -> ()
     in
     blocking_write fd; go ()

--- a/lib/miou_unix.mli
+++ b/lib/miou_unix.mli
@@ -70,7 +70,7 @@ val read : file_descr -> bytes -> off:int -> len:int -> int
 (** [read fd buf ~off ~len] reads [len] bytes from [fd] into [buf] starting at
     [off]. Return the number of bytes actually read. *)
 
-val write : file_descr -> string -> off:int -> len:int -> unit
+val write : file_descr -> bytes -> off:int -> len:int -> unit
 (** [write fd str ~off ~len] writes [len] bytes starting at [off] from [str] on
     [fd]. *)
 

--- a/tutorials/echo/main.ml
+++ b/tutorials/echo/main.ml
@@ -3,7 +3,7 @@ let handler fd =
   let rec go () =
     let len = Miou_unix.read fd buf ~off:0 ~len:(Bytes.length buf) in
     if len > 0 then begin
-      Miou_unix.write fd (Bytes.unsafe_to_string buf) ~off:0 ~len;
+      Miou_unix.write fd buf ~off:0 ~len;
       go ()
     end
     else Miou_unix.close fd


### PR DESCRIPTION
Both `Lwt_unix.write` and `Unix` take `bytes` as input instead of string. I think keeping it this way would make it easier to miou-ify existing projects.

Also, as a side note: one of the example makes it clear that people usually already have a `bytes` type and not a `string` type when using this function.